### PR TITLE
Add missing override server object definition

### DIFF
--- a/lib/config_loader.rb
+++ b/lib/config_loader.rb
@@ -19,6 +19,7 @@ def loadConfig()
 
     if config["override"]["servers"]
         config["override"]["servers"].each do |key, value|
+            result["servers"][key] = {}
             value.each do |server_key, server_value|
                 result["servers"][key][server_key] = server_value
             end


### PR DESCRIPTION
The following Error was being thrown when using config.json:
```
Message: NoMethodError: undefined method `[]=' for nil:NilClass
```